### PR TITLE
Proposed changes to the method get_page_size() in PDF::Create

### DIFF
--- a/lib/PDF/Create.pm
+++ b/lib/PDF/Create.pm
@@ -576,7 +576,7 @@ sub new_outline
 sub get_page_size
 {
 	my $self = shift;
-	my $name = lc(shift);
+	my $name = shift;
 
 	my %pagesizes = ( 'A0'         => [ 0, 0, 2380, 3368 ],
 					  'A1'         => [ 0, 0, 1684, 2380 ],
@@ -594,12 +594,16 @@ sub get_page_size
 					  'EXECUTIVE'  => [ 0, 0, 522,  756 ],
 					  '36X36'      => [ 0, 0, 2592, 2592 ],
 					);
+        if (defined $name) {
+            $name = uc($name);
+            # validate page size
+            croak "Invalid page size name '$name' received." unless (exists $pagesizes{$name});
+        }
+        else {
+            $name = 'A4';
+        }
 
-	if ( !$pagesizes{ uc($name) } ) {
-		$name = "A4";
-	}
-
-	$pagesizes{ uc($name) };
+	return $pagesizes{$name};
 }
 
 sub new_page
@@ -1404,8 +1408,8 @@ is rotated.
 =item * get_page_size(<pagesize>)
 
 Returns the size of standard paper sizes to use for MediaBox-parameter
-of C<new_page>. C<get_page_size> has one required parameter to 
-specify the paper name. Possible values are a0-a6, letter, broadsheet,
+of C<new_page>. C<get_page_size> has one optional parameter to 
+specify the paper name. Possible values are a0-a6, a4l, letter, broadsheet,
 ledger, tabloid, legal, executive and 36x36. Default is a4.
 
   my $root = $pdf->new_page( 'MediaBox' => $pdf->get_page_size('A4') );

--- a/t/10-generic.t
+++ b/t/10-generic.t
@@ -69,6 +69,16 @@ eval {
 };
 like($@, qr/Received invalid value/);
 
+eval { $pdf->get_page_size('AA') };
+like($@, qr/Invalid page size 'AA' received/);
+
+foreach (qw/A0 A1 A2 A3 A4 A4L A5 A6
+            LETTER BROADSHEET LEDGER TABLOID
+            LEGAL EXECUTIVE 36X36/) {
+    eval { $pdf->get_page_size($_) };
+    is($@, '');
+}
+
 ok(!$pdf->close(), "Close PDF");
 
 my %params = ('filenam' => "$pdfname",

--- a/t/10-generic.t
+++ b/t/10-generic.t
@@ -70,7 +70,7 @@ eval {
 like($@, qr/Received invalid value/);
 
 eval { $pdf->get_page_size('AA') };
-like($@, qr/Invalid page size 'AA' received/);
+like($@, qr/Invalid page size name 'AA' received/);
 
 foreach (qw/A0 A1 A2 A3 A4 A4L A5 A6
             LETTER BROADSHEET LEDGER TABLOID


### PR DESCRIPTION
Hi Gabor,

I have found few issues with the method get_page_size() in the package PDF::Create as below:

Line 547: $name = lc(shift);

What if the parameter to the method get_page_size() is undef, we are performing unnecessary action lc() on it. 

Line 566: if ( !$pagesizes{ uc($name) } ) {

Also what is the point of doing lc() earlier when we are doing uc() here.

Line 570: $pagesizes{ uc($name) };

We are doing uc() again, which is repeating our self/

My proposed solution (with unit test, of course) are as below:
- Accept the parameter as it arrives i.e $name = shift;
- Check if it is defined then uc($name) and compare against the keys defined in %pagesize. Croak if it is invalid name.
- In case it is not defined then assign the default value 'A4'
- Finally return $pagesizes{$name};

Also the pod document missing one page name i.e. 'A4L'. I have updated it. Last but not the least, I replaced the word "required" with "optional" as the parameter to the method get_page_size () is optional and not required.

Please review the changes.

Many Thanks.

Best Regards,
Mohammad S Anwar
